### PR TITLE
Add method for sending mail without template and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ server.pack.register pluginConf, (err) ->
 fnCallback = (err,result) ->
   # Do some stuff when done.
 
-plugin = server.pack.plugins['hapi-mandrill']
+plugin = server.plugins['hapi-mandrill']
 
 plugin.send("Angelina Jolie","angelina@jolie.com", {some: "payload"},"Hello Angelina","angelina-template", fnCallback)
 
@@ -59,7 +59,7 @@ key is not found it will be passed verbatim.
 
 ## Exposed Properties
 ```Coffeescript
-plugin = server.pack.plugins['hapi-mandrill']
+plugin = server.plugins['hapi-mandrill']
 
 plugin.mandrillClient # Note this is null if you do not pass a key in options
 plugin.send(...)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ server.pack.register pluginConf, (err) ->
 
 ```
 
-## Send Mail
+## Send Mail Using Template
 ```Coffeescript
 
 fnCallback = (err,result) ->
@@ -46,7 +46,32 @@ fnCallback = (err,result) ->
 plugin = server.plugins['hapi-mandrill']
 
 plugin.send("Angelina Jolie","angelina@jolie.com", {some: "payload"},"Hello Angelina","angelina-template", fnCallback)
+```
 
+## Send Mail without Template
+```
+fnCallback = (err,result) ->
+  # Do some stuff when done.
+ 
+var	plugin = server.plugins['hapi-mandrill'],
+	message = {                                       
+		from_email: "from@domain.tld",
+		from_name: "Person From",
+		to: [
+			{
+				email: "to@domain.tld",
+				name: "Person To",
+				type: "to"
+			}
+		],
+		subject: "Email Subject",
+		text: "Email Text",
+		html: "<p>Email HTML</p>"
+	};
+
+
+// See https://mandrillapp.com/api/docs/messages.JSON.html#method=send for full Message API definition
+plugin.sendNoTemplate( message , fnCallback )
 ```
 
 ## Logging
@@ -64,7 +89,6 @@ plugin = server.plugins['hapi-mandrill']
 plugin.mandrillClient # Note this is null if you do not pass a key in options
 plugin.send(...)
 plugin.templateNameMapping = {...}
-
 ```
 
 ## See also

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,11 +83,18 @@
             }
           ],
           track_opens: true,
+          track_clicks: true,
           auto_text: true,
           auto_html: true,
           inline_css: true
         }
       };
+
+      if ( options.tracking_domain ) {
+        sendTemplateOptions.tracking_domain = options.tracking_domain;
+        sendTemplateOptions.signing_domain = options.tracking_domain;
+        sendTemplateOptions.return_path_domain = options.tracking_domain;
+      }
       if (global_merge_vars) {
         sendTemplateOptions.message.global_merge_vars = global_merge_vars;
       }
@@ -115,8 +122,38 @@
         return success({});
       }
     };
+
+    sendNoTemplate = function( message, cb2 ) {
+      var success, error;
+
+      if (cb2 == null) {
+        cb2 = function() {};
+      }
+
+      success = function(result) {
+        if (options.verbose) {
+          server.log(['info', 'plugin', 'email-sent', 'hapi-mandrill', 'success'], "Successfully sent email", result);
+        }
+        return cb2(null, result);
+      },
+
+      error = function(err) {
+        if (options.verbose) {
+          server.log(['error', 'plugin', 'email-not-sent', 'hapi-mandrill', 'failure'], "Failed to send email for reason " + err, err);
+        }
+        return cb2(err);
+      };
+
+      if (mandrillClient) {
+        return mandrillClient.messages.send( { message: message, async: true }, success, error); // options.key
+      } else {
+        return success({});
+      }
+    };
+
     server.expose('mandrillClient', mandrillClient);
     server.expose('send', send);
+    server.expose('sendNoTemplate', sendNoTemplate);
     server.expose('templateNameMapping', templateNameMapping);
     return cb();
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-mandrill",
   "description": "HAPI plugin that exposes mandrill api - used to send transactional emails.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": false,
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/codedoctor/hapi-mandrill.git"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": ">=0.10.x"
   },
   "scripts": {
     "test": "node_modules/.bin/grunt testandcoverage"


### PR DESCRIPTION
Also updated README.md for the new method and fixed a minor refrence (hapi 8 server.pack is gone).

I did look at adding a test, but I don't use coffeescript and can barely read it, but the implementation is very simple so for someone that does know coffeescript, adding a test should take minutes.
